### PR TITLE
Display number of active cases in the infobox.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -217,7 +217,7 @@ div#footer>div {
   background: #343a40;
   color: white;
   opacity: 1;
-  padding: 40px 15px 20px 15px;
+  padding: 15px 15px 20px 15px;
 }
 
 .card-deck .card {

--- a/css/main.css
+++ b/css/main.css
@@ -329,8 +329,8 @@ span {
   left: -10px;
 }
 
-.counts {
-  margin-top: -20px;
+#date-row {
+  margin-bottom:-30px;
 }
 
 text {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       </div>
 
       <p><span id="placename">Global Trend</span> </p>
-      <p> <span id="date"></span> <span id="hint"> Click a place to review local trend.</span></p>
+      <p id="date-row"> <span id="date"></span> <span id="hint"> Click a place to review local trend.</span></p>
       <div class="card-deck counts">
         <div class="card">
           <div class="card-body confirmed">
@@ -55,7 +55,8 @@
             <p class="card-text active-count">0</p>
           </div>
         </div>
-
+      </div>
+      <div class="card-deck counts">
         <div class="card">
           <div class="card-body recovered">
             <h5 class="card-title">Recovered</h5>
@@ -595,7 +596,7 @@
         });
 
         $(".confirmed-count").text(cf);
-        $(".active-count").text(cf-rc);
+        $(".active-count").text(cf-rc-dd);
         $(".recovered-count").text(rc);
         $(".death-count").text(dd);
         

--- a/index.html
+++ b/index.html
@@ -511,13 +511,13 @@
       var confirmed = ["Confirmed"];
       var suspected = ["Suspected"];
       var recovered = ["Recovered"];
-      var death = ["Death"]
+      var dead = ["Dead"]
       var global = {
         name: "Global Trend",
         c: confirmed,
         s: suspected,
         r: recovered,
-        d: death
+        d: dead
 
       }
 
@@ -698,13 +698,13 @@
         var confirmed = ["Confirmed"];
         var suspected = ["Suspected"];
         var recovered = ["Recovered"];
-        var death = ["Death"]
+        var dead = ["Dead"]
         var place = {
           name: e.target.feature.properties.enname,
           c: confirmed,
           s: suspected,
           r: recovered,
-          d: death
+          d: dead
         }
 
         calCounts(place);
@@ -713,7 +713,7 @@
 
         chart.load({
           columns: [place.c, place.r, place.d],
-          unload: ['Confirmed', 'Recovered', 'Death'],
+          unload: ['Confirmed', 'Recovered', 'Dead'],
         });
 
 
@@ -756,7 +756,7 @@
         calCounts(global);
         chart.load({
           columns: [global.c, global.r, global.d],
-          unload: ['Confirmed', 'Recovered', 'Death'],
+          unload: ['Confirmed', 'Recovered', 'Dead'],
         });
 
         $("#hint").text("Click a place to review local trend.");
@@ -790,7 +790,7 @@
             Confirmed: '#dc3545',
             // Suspected: 'orange',
             Recovered: '#28a745',
-            Death: '#5d4f72e8'
+            Dead: '#5d4f72e8'
           }
         },
         // zoom: {

--- a/index.html
+++ b/index.html
@@ -595,10 +595,10 @@
           i["d"].push(dd);
         });
 
-        $(".confirmed-count").text(cf);
-        $(".active-count").text(cf-rc-dd);
-        $(".recovered-count").text(rc);
-        $(".death-count").text(dd);
+        $(".confirmed-count").text(cf.toLocaleString());
+        $(".active-count").text((cf-rc-dd).toLocaleString());
+        $(".recovered-count").text(rc.toLocaleString());
+        $(".death-count").text(dd.toLocaleString());
         
 
         if (i["name"] == "anhui" || i["name"] == "beijing" || i["name"] == "chongqing" || i["name"] == "fujian" || i["name"] == "gansu" || i["name"] == "guangdong" ||

--- a/index.html
+++ b/index.html
@@ -49,12 +49,13 @@
           <p class="card-text confirmed-count">0</p>
         </div>
 
-        <!-- <div class="card">
-          <div class="card-body suspected">
-            <h5 class="card-title">Suspected</h5>
-            <p class="card-text suspected-count">0</p>
+         <div class="card">
+          <div class="card-body active">
+            <h5 class="card-title">Active</h5>
+            <p class="card-text active-count">0</p>
           </div>
-        </div> -->
+        </div>
+
         <div class="card">
           <div class="card-body recovered">
             <h5 class="card-title">Recovered</h5>
@@ -64,7 +65,7 @@
 
         <div class="card">
           <div class="card-body death">
-            <h5 class="card-title">Death</h5>
+            <h5 class="card-title">Dead</h5>
             <p class="card-text death-count">0</p>
           </div>
         </div>
@@ -594,9 +595,10 @@
         });
 
         $(".confirmed-count").text(cf);
-        // $(".suspected-count").text(sp);
+        $(".active-count").text(cf-rc);
         $(".recovered-count").text(rc);
         $(".death-count").text(dd);
+        
 
         if (i["name"] == "anhui" || i["name"] == "beijing" || i["name"] == "chongqing" || i["name"] == "fujian" || i["name"] == "gansu" || i["name"] == "guangdong" ||
           i["name"] == "guangxi" || i["name"] == "guizhou" || i["name"] == "hainan" || i["name"] == "hebei" || i["name"] == "heilongjiang" || i["name"] == "henan" || i["name"] == "hongkong" ||


### PR DESCRIPTION
Hello. I think it would be valuable to have also a number of active cases displayed, as that's what really determines an immediate impact of the disease on local society. It looks like this:

![image](https://user-images.githubusercontent.com/728780/76289943-93b07980-62aa-11ea-8aef-5ed04729bada.png)

As you see in the screenshot, I have also made some minor visual adjustments so that the numbers fit into the info column and have thousands separators. Judging by the latest development, it seems we would have needed this additional space for additional orders of magnitude anyway :(